### PR TITLE
chore: fix CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# textlint-rule-no-nfd [![Actions Status: test](https://github.com/textlint-ja/textlint-rule-no-nfd.svg?branch=master)](https://travis-ci.org/textlint-ja/textlint-rule-no-nfd) [![textlint rule](https://img.shields.io/badge/textlint-fixable-green/workflows/test/badge.svg)](https://github.com/textlint-ja/textlint-rule-no-nfd.svg?branch=master)](https://travis-ci.org/textlint-ja/textlint-rule-no-nfd) [![textlint rule](https://img.shields.io/badge/textlint-fixable-green/actions?query=workflow%3A"test") 
+# textlint-rule-no-nfd [![Actions Status: test](https://github.com/textlint-ja/textlint-rule-no-nfd/workflows/test/badge.svg)](https://github.com/textlint-ja/textlint-rule-no-nfd/actions?query=workflow%3A"test") [![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
 
 [textlint](https://textlint.github.io/ "textlint") rule that disallow to use NFD like UTF8-MAC 濁点.
 


### PR DESCRIPTION
The README badges have been broken since CI was migrated to GitHub Actions.

This PR fixes badges.