### PR TITLE
chore: replace unorm with String.prototype.normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ via [Unicodeの特殊な文字 “結合文字列” | ものかの](http://tama
 単独で存在できる゜`\u309b`と゛`\u309c`は置換することでnormalizeする。
 
 - [String.prototype.normalize() - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/normalize)
-- [walling/unorm: JavaScript Unicode 8.0 Normalization - NFC, NFD, NFKC, NFKD.](https://github.com/walling/unorm)
 - [UTF-8にもいろいろある - ザリガニが見ていた...。](http://d.hatena.ne.jp/zariganitosh/20131124/utf8_nfd_nfc_bom)
 - [[JavaScript]\uXXXX形式にunicodeエスケープする関数 / LiosK-free Blog](http://liosk.blog103.fc2.com/blog-entry-67.html)
 - [unoh.github.com by unoh](http://unoh.github.io/2007/09/04/unicode-on-mac.html)

--- a/package.json
+++ b/package.json
@@ -33,14 +33,12 @@
   "devDependencies": {
     "@textlint/types": "^13.0.2",
     "@types/node": "^18.11.18",
-    "@types/unorm": "^1.3.28",
     "textlint-scripts": "^13.0.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
   },
   "dependencies": {
     "match-index": "^1.0.3",
-    "textlint-rule-helper": "^2.3.0",
-    "unorm": "^1.4.1"
+    "textlint-rule-helper": "^2.3.0"
   }
 }

--- a/src/textlint-rule-no-nfd.ts
+++ b/src/textlint-rule-no-nfd.ts
@@ -3,7 +3,6 @@
 import { matchCaptureGroupAll } from "match-index"
 import { RuleHelper } from "textlint-rule-helper";
 import { TextlintRuleReporter } from "@textlint/types";
-import unorm from "unorm";
 
 const reporter: TextlintRuleReporter = function (context) {
     const { Syntax, RuleError, report, fixer, getSource, locator } = context;
@@ -21,7 +20,7 @@ const reporter: TextlintRuleReporter = function (context) {
                 // \u309b\u309c => \u309a\u3099
                 const dakutenChars = text.slice(index - 1, index + 1);
                 const nfdlized = dakutenChars.replace("\u309B", "\u3099").replace("\u309C", "\u309A");
-                const expectedText = unorm.nfc(nfdlized);
+                const expectedText = nfdlized.normalize('NFC');
                 const ruleError = new RuleError(`Disallow to use NFD(well-known as UTF8-MAC 濁点): "${dakutenChars}" => "${expectedText}"`, {
                     padding: locator.at(index),
                     fix: fixer.replaceTextRange([index - 1, index + 1], expectedText)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,11 +1160,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@types/unorm@^1.3.28":
-  version "1.3.28"
-  resolved "https://registry.yarnpkg.com/@types/unorm/-/unorm-1.3.28.tgz#580141162f2fd221faae2b2d68da6c839402c375"
-  integrity sha512-l3uh18vcvkQ964HSK7Tx0YbhxN/Hj+k1w3nLT08n770lngqVKljmF7Ht4e7elFbx6L2WYse97whtpJOo8MHtxQ==
-
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
@@ -3028,11 +3023,6 @@ unist-util-visit@^2.0.3:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
-
-unorm@^1.4.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
-  integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
 
 update-browserslist-db@^1.0.9:
   version "1.0.10"


### PR DESCRIPTION
String.prototype.normalize is fully supported by node.js with small-icu.

https://nodejs.org/docs/latest-v12.x/api/intl.html

We can repleace unorm package with String.prototype.normalize.